### PR TITLE
Add Qwen3 14B MoE upcycling example

### DIFF
--- a/examples/qwen/README.md
+++ b/examples/qwen/README.md
@@ -1,0 +1,29 @@
+# Qwen3 14B MoE Upcycling Example
+
+This example demonstrates how to convert a dense Hugging Face checkpoint of Qwen3-14B into a Mixture-of-Experts (MoE) model using Megatron-Core's upcycling utility, and then start finetuning.
+
+1. Convert the Hugging Face checkpoint to Megatron format:
+
+```bash
+TOKENIZER_MODEL=/path/to/tokenizer.model
+HF_FORMAT_DIR=/path/to/hf/Qwen3-14B
+MEGATRON_FORMAT_DIR=/path/to/megatron/Qwen3-14B-dense
+
+python tools/checkpoint/convert.py \
+    --model-type GPT \
+    --loader loader_hf \
+    --saver mcore \
+    --target-tensor-parallel-size 1 \
+    --target-pipeline-parallel-size 1 \
+    --load-dir ${HF_FORMAT_DIR} \
+    --save-dir ${MEGATRON_FORMAT_DIR} \
+    --tokenizer-model ${TOKENIZER_MODEL}
+```
+
+2. Launch training with MoE upcycling enabled:
+
+```bash
+bash examples/qwen/train_qwen3_14b_moe_upcycling.sh /path/to/moe-checkpoint ${MEGATRON_FORMAT_DIR} ${TOKENIZER_MODEL} /path/to/data
+```
+
+The script loads the dense checkpoint from `--load`, converts it to the MoE format on the fly and stores the converted model under `--save` before training resumes.

--- a/examples/qwen/README.md
+++ b/examples/qwen/README.md
@@ -1,8 +1,13 @@
-# Qwen3 14B MoE Upcycling Example
+# Qwen3 MoE Upcycling Examples
 
-This example demonstrates how to convert a dense Hugging Face checkpoint of Qwen3-14B into a Mixture-of-Experts (MoE) model using Megatron-Core's upcycling utility, and then start finetuning.
+This example demonstrates how to convert dense Hugging Face checkpoints of Qwen3 models into Mixture-of-Experts (MoE) models using Megatron-Core's upcycling utility and then start finetuning.
+The `train_qwen3_14b_moe_upcycling.sh` script uses 64 experts so the resulting model stays under 140B parameters.
 
-1. Convert the Hugging Face checkpoint to Megatron format:
+## 1. Convert Hugging Face checkpoints
+
+The following commands convert a Hugging Face format checkpoint to Megatron format.
+
+### Qwen3-14B
 
 ```bash
 TOKENIZER_MODEL=/path/to/tokenizer.model
@@ -20,10 +25,44 @@ python tools/checkpoint/convert.py \
     --tokenizer-model ${TOKENIZER_MODEL}
 ```
 
-2. Launch training with MoE upcycling enabled:
+### Qwen3-1.6B
 
 ```bash
-bash examples/qwen/train_qwen3_14b_moe_upcycling.sh /path/to/moe-checkpoint ${MEGATRON_FORMAT_DIR} ${TOKENIZER_MODEL} /path/to/data
+TOKENIZER_MODEL=/path/to/tokenizer.model
+HF_FORMAT_DIR=/path/to/hf/Qwen3-1.6B
+MEGATRON_FORMAT_DIR=/path/to/megatron/Qwen3-1.6B-dense
+
+python tools/checkpoint/convert.py \
+    --model-type GPT \
+    --loader loader_hf \
+    --saver mcore \
+    --target-tensor-parallel-size 1 \
+    --target-pipeline-parallel-size 1 \
+    --load-dir ${HF_FORMAT_DIR} \
+    --save-dir ${MEGATRON_FORMAT_DIR} \
+    --tokenizer-model ${TOKENIZER_MODEL}
 ```
 
-The script loads the dense checkpoint from `--load`, converts it to the MoE format on the fly and stores the converted model under `--save` before training resumes.
+## 2. Launch training with MoE upcycling enabled
+
+### Qwen3-14B
+
+```bash
+bash examples/qwen/train_qwen3_14b_moe_upcycling.sh \ 
+    /path/to/moe-checkpoint \ 
+    /path/to/megatron/Qwen3-14B-dense \ 
+    /path/to/tokenizer.model \ 
+    /path/to/data
+```
+
+### Qwen3-1.6B
+
+```bash
+bash examples/qwen/train_qwen3_1_6b_moe_upcycling.sh \ 
+    /path/to/moe-checkpoint \ 
+    /path/to/megatron/Qwen3-1.6B-dense \ 
+    /path/to/tokenizer.model \ 
+    /path/to/data
+```
+
+The scripts load the dense checkpoints from `--load`, convert them to the MoE format on the fly and store the converted model under `--save` before training resumes.

--- a/examples/qwen/train_qwen3_14b_moe_upcycling.sh
+++ b/examples/qwen/train_qwen3_14b_moe_upcycling.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Runs Qwen3 14B with MoE upcycling
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+GPUS_PER_NODE=8
+MASTER_ADDR=${MASTER_ADDR:-"localhost"}
+MASTER_PORT=${MASTER_PORT:-"6000"}
+NNODES=${NNODES:-"1"}
+NODE_RANK=${RANK:-"0"}
+WORLD_SIZE=$(($GPUS_PER_NODE*$NNODES))
+
+CHECKPOINT_PATH=$1       # Path to save the MoE checkpoint
+DENSE_CHECKPOINT=$2      # Path to the converted dense checkpoint
+TOKENIZER_MODEL=$3       # Path to tokenizer.model
+DATA_PATH=$4             # Path to training data
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node $GPUS_PER_NODE
+    --nnodes $NNODES
+    --node_rank $NODE_RANK
+    --master_addr $MASTER_ADDR
+    --master_port $MASTER_PORT
+)
+
+MODEL_ARGS=(
+    --use-mcore-models
+    --disable-bias-linear
+    --seq-length 4096
+    --max-position-embeddings 32768
+    --num-layers 40
+    --hidden-size 5120
+    --ffn-hidden-size 13696
+    --num-attention-heads 40
+    --init-method-std 0.01
+    --attention-dropout 0.0
+    --hidden-dropout 0.0
+    --normalization RMSNorm
+    --position-embedding-type rope
+    --swiglu
+    --untie-embeddings-and-output-weights
+    --group-query-attention
+    --num-query-groups 8
+    --no-masked-softmax-fusion
+    --no-position-embedding
+    --rotary-base 1000000
+)
+
+MOE_ARGS=(
+    --num-experts 128
+    --moe-ffn-hidden-size 1712
+    --moe-router-topk 8
+    --moe-router-dtype fp32
+    --moe-aux-loss-coeff 1e-3
+    --moe-token-dispatcher-type alltoall
+    --moe-router-load-balancing-type aux_loss
+    --moe-layer-recompute
+    --moe-grouped-gemm
+    --moe-permute-fusion
+    --moe-upcycling-granularity 8
+    --moe-use-upcycling
+)
+
+DATA_ARGS=(
+    --tokenizer-type HuggingFaceTokenizer
+    --tokenizer-model ${TOKENIZER_MODEL}
+    --data-path $DATA_PATH
+    --split 99990,8,2
+)
+
+TRAINING_ARGS=(
+    --micro-batch-size 1
+    --global-batch-size 128
+    --lr 1e-4
+    --train-iters 500000
+    --lr-decay-iters 320000
+    --lr-decay-style cosine
+    --min-lr 1.0e-5
+    --weight-decay 0.1
+    --lr-warmup-iters 500
+    --clip-grad 1.0
+    --bf16
+    --overlap-grad-reduce
+    --overlap-param-gather
+)
+
+MODEL_PARALLEL_ARGS=(
+    --tensor-model-parallel-size 1
+    --pipeline-model-parallel-size 4
+    --expert-model-parallel-size 8
+    --sequence-parallel
+    --use-distributed-optimizer
+)
+
+LOGGING_ARGS=(
+    --log-interval 1 \
+    --save-interval 10000 \
+    --eval-interval 1000 \
+    --eval-iters 10 \
+    --save $CHECKPOINT_PATH \
+    --load $DENSE_CHECKPOINT \
+    --tensorboard-dir "${CHECKPOINT_PATH}/tensorboard" \
+    --no-load-optim \
+    --no-load-rng
+)
+
+torchrun ${DISTRIBUTED_ARGS[@]} pretrain_gpt.py \
+    ${MODEL_ARGS[@]} \
+    ${MOE_ARGS[@]} \
+    ${DATA_ARGS[@]} \
+    ${TRAINING_ARGS[@]} \
+    ${MODEL_PARALLEL_ARGS[@]} \
+    ${LOGGING_ARGS[@]}

--- a/examples/qwen/train_qwen3_1_6b_moe_upcycling.sh
+++ b/examples/qwen/train_qwen3_1_6b_moe_upcycling.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Runs Qwen3 14B with MoE upcycling
+# Runs Qwen3 1.6B with MoE upcycling
 
 export CUDA_DEVICE_MAX_CONNECTIONS=1
 
@@ -29,10 +29,10 @@ MODEL_ARGS=(
     --disable-bias-linear
     --seq-length 4096
     --max-position-embeddings 32768
-    --num-layers 40
-    --hidden-size 5120
-    --ffn-hidden-size 13696
-    --num-attention-heads 40
+    --num-layers 24
+    --hidden-size 2048
+    --ffn-hidden-size 5504
+    --num-attention-heads 16
     --init-method-std 0.01
     --attention-dropout 0.0
     --hidden-dropout 0.0
@@ -41,16 +41,16 @@ MODEL_ARGS=(
     --swiglu
     --untie-embeddings-and-output-weights
     --group-query-attention
-    --num-query-groups 8
+    --num-query-groups 4
     --no-masked-softmax-fusion
     --no-position-embedding
     --rotary-base 1000000
 )
 
 MOE_ARGS=(
-    --num-experts 64
-    --moe-ffn-hidden-size 1712
-    --moe-router-topk 8
+    --num-experts 32
+    --moe-ffn-hidden-size 768
+    --moe-router-topk 4
     --moe-router-dtype fp32
     --moe-aux-loss-coeff 1e-3
     --moe-token-dispatcher-type alltoall
@@ -87,8 +87,8 @@ TRAINING_ARGS=(
 
 MODEL_PARALLEL_ARGS=(
     --tensor-model-parallel-size 1
-    --pipeline-model-parallel-size 4
-    --expert-model-parallel-size 8
+    --pipeline-model-parallel-size 1
+    --expert-model-parallel-size 4
     --sequence-parallel
     --use-distributed-optimizer
 )


### PR DESCRIPTION
## Summary
- add an example for converting HF Qwen3-14B into an MoE model using the upcycling utility
- provide shell script for training with upcycling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688444e92fbc8326942ec5be2d8839e6