### PR TITLE
Add dataset preprocessing to Qwen upcycling example

### DIFF
--- a/examples/qwen/README.md
+++ b/examples/qwen/README.md
@@ -1,0 +1,58 @@
+# Qwen3 1.6B MoE Upcycling Example
+
+This example shows how to convert the **Qwen3 1.6B** checkpoint from
+HuggingFace format to Megatron format and train it using the MoE
+upcycling feature. The script assumes a single node with eight GPUs.
+
+## 1. Convert the HuggingFace checkpoint
+
+```bash
+HF_FORMAT_DIR=/path/to/qwen3-1_6b-hf
+MEGATRON_FORMAT_DIR=/path/to/qwen3-1_6b-mcore
+TOKENIZER_MODEL=/path/to/tokenizer.model
+
+python tools/checkpoint/convert.py \
+    --bf16 \
+    --model-type GPT \
+    --loader llama_mistral \
+    --saver core \
+    --target-tensor-parallel-size 1 \
+    --checkpoint-type hf \
+    --load-dir ${HF_FORMAT_DIR} \
+    --save-dir ${MEGATRON_FORMAT_DIR} \
+    --tokenizer-model ${TOKENIZER_MODEL} \
+    --model-size llama3
+```
+
+## 2. Preprocess a dataset
+
+If you have a JSONL dataset with a `text` column, convert it to Megatron's
+binary format using `tools/preprocess_data.py`:
+
+```bash
+python tools/preprocess_data.py \
+    --input /path/to/my_corpus.jsonl \
+    --json-keys text \
+    --tokenizer-type HuggingFaceTokenizer \
+    --tokenizer-model ${TOKENIZER_MODEL} \
+    --output-prefix /path/to/my_dataset_text_document \
+    --append-eod
+```
+
+The command produces `.bin` and `.idx` files prefixed with
+`my_dataset_text_document` that can be passed to `--data-path` during training.
+
+## 3. Train with MoE upcycling
+
+Use the provided shell script to launch training from the repository root.
+It loads the converted checkpoint and enables MoE upcycling at runtime.
+
+```bash
+bash examples/qwen/train_qwen3_1_6b_moe_upcycling.sh \
+    /path/to/qwen3-1_6b-mcore \
+    /path/to/tokenizer.model \
+    /path/to/my_dataset_text_document
+```
+
+The script sets up distributed arguments for an 8–GPU node and trains the
+model with `--moe-use-upcycling`.

--- a/examples/qwen/train_qwen3_1_6b_moe_upcycling.sh
+++ b/examples/qwen/train_qwen3_1_6b_moe_upcycling.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -e
+
+# Runs Qwen3 1.6B model with MoE upcycling. The script assumes it is run
+# from the root of the Megatron-LM repository. Pass paths to the converted
+# checkpoint, tokenizer model, and preprocessed dataset prefix.
+
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+GPUS_PER_NODE=8
+MASTER_ADDR=${MASTER_ADDR:-"localhost"}
+MASTER_PORT=${MASTER_PORT:-"6000"}
+NNODES=${NNODES:-"1"}
+NODE_RANK=${RANK:-"0"}
+
+PRETRAIN_SCRIPT_PATH="pretrain_gpt.py"
+
+CHECKPOINT_PATH=$1   # path to converted checkpoint
+TOKENIZER_MODEL=$2   # path to tokenizer.model
+DATA_PATH=$3         # prefix for dataset (_text_document)
+
+# Ensure pretrain_gpt.py exists
+if [ ! -f "$PRETRAIN_SCRIPT_PATH" ]; then
+    echo "Error: $PRETRAIN_SCRIPT_PATH not found. Run from repository root." >&2
+    exit 1
+fi
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node $GPUS_PER_NODE
+    --nnodes $NNODES
+    --node_rank $NODE_RANK
+    --master_addr $MASTER_ADDR
+    --master_port $MASTER_PORT
+)
+
+MODEL_ARGS=(
+    --use-mcore-models
+    --num-layers 24
+    --hidden-size 2048
+    --ffn-hidden-size 5492
+    --num-attention-heads 16
+    --seq-length 4096
+    --max-position-embeddings 4096
+    --position-embedding-type rope
+    --normalization rmsnorm
+    --swiglu
+    --disable-bias-linear
+    --untie-embeddings-and-output-weights
+)
+
+MOE_ARGS=(
+    --num-experts 4
+    --expert-model-parallel-size 1
+    --moe-use-upcycling
+    --moe-upcycling-granularity 1
+)
+
+DATA_ARGS=(
+    --tokenizer-type HuggingFaceTokenizer
+    --tokenizer-model ${TOKENIZER_MODEL}
+    --data-path ${DATA_PATH}
+    --split 949,50,1
+)
+
+TRAINING_ARGS=(
+    --micro-batch-size 1
+    --global-batch-size 8
+    --train-iters 100
+    --lr 1e-4
+    --min-lr 1e-5
+    --lr-decay-style cosine
+    --bf16
+)
+
+LOGGING_ARGS=(
+    --log-interval 1
+    --save-interval 50
+    --eval-interval 50
+    --eval-iters 10
+    --save ${CHECKPOINT_PATH}
+    --load ${CHECKPOINT_PATH}
+)
+
+torchrun ${DISTRIBUTED_ARGS[@]} "$PRETRAIN_SCRIPT_PATH" \
+    ${MODEL_ARGS[@]} \
+    ${MOE_ARGS[@]} \
+    ${DATA_ARGS[@]} \
+    ${TRAINING_ARGS[@]} \
+    ${LOGGING_ARGS[@]}
+
+


### PR DESCRIPTION
## Summary
- document converting JSONL text to Megatron dataset
- accept data path in Qwen upcycling script
- show example command using dataset prefix

## Testing
- `bash -n examples/qwen/train_qwen3_1_6b_moe_upcycling.sh`
- `bash examples/qwen/train_qwen3_1_6b_moe_upcycling.sh /tmp/check /tmp/tok /tmp/data` *(terminated manually)*

------
https://chatgpt.com/codex/tasks/task_e_68844d327c1c8326ba747ed4654754e2